### PR TITLE
[Feat] 회원가입 기능 및 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,11 @@ HELP.md
 build/
 out/
 
-# application 설정 파일 무시
+# 환경 설정
+.env
+*.env
 src/main/resources/application.yml
-src/main/resources/application-*.yml
+src/test/resources/application.yml
 
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
@@ -46,6 +48,3 @@ bin/
 
 # Log
 *.log
-
-# 환경 설정
-.env

--- a/src/main/java/jiwon/todo/api/MemberApiController.java
+++ b/src/main/java/jiwon/todo/api/MemberApiController.java
@@ -1,0 +1,4 @@
+package jiwon.todo.api;
+
+public class MemberApiController {
+}

--- a/src/main/java/jiwon/todo/api/MemberApiController.java
+++ b/src/main/java/jiwon/todo/api/MemberApiController.java
@@ -1,4 +1,43 @@
 package jiwon.todo.api;
 
+import jakarta.validation.Valid;
+import jiwon.todo.domain.Member;
+import jiwon.todo.service.MemberService;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController // @@Controller + @ResponseBody
+@RequiredArgsConstructor
 public class MemberApiController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/api/members")
+    public CreateMemberResponse saveMember(@RequestBody @Valid CreateMemberRequest request){
+        Member member = new Member(request.getLoginId(), request.getPassword(),
+                                    request.getName(), request.getEmail());
+
+        Long id = memberService.join(member);
+        return new CreateMemberResponse(id);
+    }
+
+    @Data
+    static class CreateMemberResponse {
+        private Long id;
+
+        public CreateMemberResponse(Long id) {
+            this.id = id;
+        }
+    }
+
+    @Data
+    static class CreateMemberRequest {
+        private String loginId;
+        private String password;
+        private String name;
+        private String email;
+    }
 }

--- a/src/main/java/jiwon/todo/api/MemberApiController.java
+++ b/src/main/java/jiwon/todo/api/MemberApiController.java
@@ -1,6 +1,9 @@
 package jiwon.todo.api;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
 import jiwon.todo.domain.Member;
 import jiwon.todo.service.MemberService;
 import lombok.Data;
@@ -35,9 +38,21 @@ public class MemberApiController {
 
     @Data
     static class CreateMemberRequest {
+        @NotEmpty(message = "이름을 입력해주세요")
+        private String name; // 이름 혹은 닉네임
+
+        @NotEmpty(message = "ID를 입력해주세요")
         private String loginId;
-        private String password;
-        private String name;
+
+        @NotEmpty(message = "비밀번호를 입력해주세요")
+        @Pattern(message = "비밀번호 형식이 올바르지 않습니다.",
+                regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&#])[A-Za-z\\d@$!%*?&#]{8,}$")
+        private String password; // 8자 이상, 대소문자 포함, 숫자 및 특수문자(@$!%*?&#) 포함
+
+        @NotEmpty(message = "이메일을 입력해주세요")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        @Pattern(regexp = "^[\\w-.]+@([\\w-]+\\.)+[\\w-]{2,4}$",
+                message = "도메인은 최소 하나 이상의 점(.)을 포함해야 합니다.")
         private String email;
     }
 }

--- a/src/main/java/jiwon/todo/controller/MemberController.java
+++ b/src/main/java/jiwon/todo/controller/MemberController.java
@@ -1,0 +1,4 @@
+package jiwon.todo.controller;
+
+public class MemberController {
+}

--- a/src/main/java/jiwon/todo/controller/MemberController.java
+++ b/src/main/java/jiwon/todo/controller/MemberController.java
@@ -1,4 +1,45 @@
 package jiwon.todo.controller;
 
+import jakarta.validation.Valid;
+import jiwon.todo.domain.Member;
+import jiwon.todo.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@Controller
+@RequiredArgsConstructor
 public class MemberController {
+    private final MemberService memberService;
+
+    @GetMapping("/members/new")
+    public String createForm(Model model){
+        model.addAttribute("memberForm", new MemberForm());
+        return "members/createMemberForm";
+    }
+
+    @PostMapping("/members/new")
+    public String create(@Valid MemberForm form, BindingResult result) {
+
+        if (result.hasErrors()) {
+            return "members/createMemberForm"; // 검증 실패 시 데이터 유지
+        }
+
+        try{
+            Member member = new Member(
+                    form.getLoginId(),
+                    form.getPassword(),
+                    form.getName(),
+                    form.getEmail());
+
+            memberService.join(member);
+            return "redirect:/";
+        } catch (IllegalStateException e){
+            result.reject("joinError", e.getMessage());
+            return "members/createMemberForm"; // 검증 실패 시 데이터 유지
+        }
+    }
 }

--- a/src/main/java/jiwon/todo/controller/MemberForm.java
+++ b/src/main/java/jiwon/todo/controller/MemberForm.java
@@ -13,13 +13,15 @@ public class MemberForm {
 
     @NotEmpty(message = "ID를 입력해주세요")
     private String loginId;
+
     @NotEmpty(message = "비밀번호를 입력해주세요")
     @Pattern(message = "비밀번호 형식이 올바르지 않습니다.",
             regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&#])[A-Za-z\\d@$!%*?&#]{8,}$")
     private String password; // 8자 이상, 대소문자 포함, 숫자 및 특수문자(@$!%*?&#) 포함
 
     @NotEmpty(message = "이메일을 입력해주세요")
-    @Email(message = "이메일 형식이 올바르지 않습니다.",
-            regexp = "^(?=.{1,64}@)[A-Za-z0-9_-]+(\\\\.[A-Za-z0-9_-]+)*@[^-][A-Za-z0-9-]+(\\\\.[A-Za-z0-9-]+)*(\\\\.[A-Za-z]{2,})$")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    @Pattern(message = "도메인은 최소 하나 이상의 점(.)을 포함해야 합니다.",
+            regexp = "^[\\w-.]+@([\\w-]+\\.)+[\\w-]{2,4}$")
     private String email;
 }

--- a/src/main/java/jiwon/todo/controller/MemberForm.java
+++ b/src/main/java/jiwon/todo/controller/MemberForm.java
@@ -1,0 +1,25 @@
+package jiwon.todo.controller;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class MemberForm {
+    @NotEmpty(message = "이름을 입력해주세요")
+    private String name; // 이름 혹은 닉네임
+
+    @NotEmpty(message = "ID를 입력해주세요")
+    private String loginId;
+    @NotEmpty(message = "비밀번호를 입력해주세요")
+    @Pattern(message = "비밀번호 형식이 올바르지 않습니다.",
+            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&#])[A-Za-z\\d@$!%*?&#]{8,}$")
+    private String password; // 8자 이상, 대소문자 포함, 숫자 및 특수문자(@$!%*?&#) 포함
+
+    @NotEmpty(message = "이메일을 입력해주세요")
+    @Email(message = "이메일 형식이 올바르지 않습니다.",
+            regexp = "^(?=.{1,64}@)[A-Za-z0-9_-]+(\\\\.[A-Za-z0-9_-]+)*@[^-][A-Za-z0-9-]+(\\\\.[A-Za-z0-9-]+)*(\\\\.[A-Za-z]{2,})$")
+    private String email;
+}

--- a/src/main/java/jiwon/todo/domain/Member.java
+++ b/src/main/java/jiwon/todo/domain/Member.java
@@ -20,4 +20,10 @@ public class Member {
 
     @OneToMany(mappedBy = "userId")
     private List<Todo> todos = new ArrayList<>();
+
+    // == 연관관계 편의 메서드 ==
+    public void addTodo(Todo todo) {
+        todos.add(todo);
+        todo.setMember(this); // 연관관계 주인도 설정해줌
+    }
 }

--- a/src/main/java/jiwon/todo/domain/Member.java
+++ b/src/main/java/jiwon/todo/domain/Member.java
@@ -12,11 +12,16 @@ public class Member {
 
     @Id @GeneratedValue
     @Column(name = "member_id", unique = true)
-    private Long id;
+    private Long id; // PK
+
+    @Column(unique = true)
+    private String loginId; // 사용자가 설정하는 ID(중복x)
 
     private String password;
+    private String name; // 이름 혹은 닉네임
 
-    private String name;
+    @Column(unique = true)
+    private String email; // 이메일(중복x)
 
     @OneToMany(mappedBy = "userId")
     private List<Todo> todos = new ArrayList<>();

--- a/src/main/java/jiwon/todo/domain/Member.java
+++ b/src/main/java/jiwon/todo/domain/Member.java
@@ -1,0 +1,4 @@
+package jiwon.todo.domain;
+
+public class Member {
+}

--- a/src/main/java/jiwon/todo/domain/Member.java
+++ b/src/main/java/jiwon/todo/domain/Member.java
@@ -28,8 +28,10 @@ public class Member {
 
 
     // == 생성자 ==
-    public Member(Long id, String loginId, String password, String name, String email) {
-        this.id = id;
+
+    protected Member() {} // JPA 기본 생성자
+
+    public Member(String loginId, String password, String name, String email) {
         this.loginId = loginId;
         this.password = password;
         this.name = name;

--- a/src/main/java/jiwon/todo/domain/Member.java
+++ b/src/main/java/jiwon/todo/domain/Member.java
@@ -1,4 +1,22 @@
 package jiwon.todo.domain;
 
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
 public class Member {
+
+    @Id @GeneratedValue
+    @Column(name = "member_id", unique = true)
+    private Long id;
+
+    private String password;
+
+    private String name;
+
+    private List<Todo> todos = new ArrayList<>();
 }

--- a/src/main/java/jiwon/todo/domain/Member.java
+++ b/src/main/java/jiwon/todo/domain/Member.java
@@ -23,7 +23,7 @@ public class Member {
     @Column(unique = true)
     private String email; // 이메일(중복x)
 
-    @OneToMany(mappedBy = "userId")
+    @OneToMany(mappedBy = "member")
     private List<Todo> todos = new ArrayList<>();
 
 

--- a/src/main/java/jiwon/todo/domain/Member.java
+++ b/src/main/java/jiwon/todo/domain/Member.java
@@ -18,5 +18,6 @@ public class Member {
 
     private String name;
 
+    @OneToMany(mappedBy = "userId")
     private List<Todo> todos = new ArrayList<>();
 }

--- a/src/main/java/jiwon/todo/domain/Member.java
+++ b/src/main/java/jiwon/todo/domain/Member.java
@@ -26,6 +26,16 @@ public class Member {
     @OneToMany(mappedBy = "userId")
     private List<Todo> todos = new ArrayList<>();
 
+
+    // == 생성자 ==
+    public Member(Long id, String loginId, String password, String name, String email) {
+        this.id = id;
+        this.loginId = loginId;
+        this.password = password;
+        this.name = name;
+        this.email = email;
+    }
+
     // == 연관관계 편의 메서드 ==
     public void addTodo(Todo todo) {
         todos.add(todo);

--- a/src/main/java/jiwon/todo/domain/Todo.java
+++ b/src/main/java/jiwon/todo/domain/Todo.java
@@ -1,8 +1,6 @@
 package jiwon.todo.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,7 +14,12 @@ import java.time.LocalDateTime;
 public class Todo {
 
     @Id @GeneratedValue
+    @Column(name = "todo_id")
     private Long id; // PK
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Long userId;
 
     private String name; // 할 일 이름
     private Boolean isDone; // 완료 여부

--- a/src/main/java/jiwon/todo/domain/Todo.java
+++ b/src/main/java/jiwon/todo/domain/Todo.java
@@ -17,9 +17,9 @@ public class Todo {
     @Column(name = "todo_id")
     private Long id; // PK
 
-    @ManyToOne
-    @JoinColumn(name = "member_id")
-    private Long userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id") // FK
+    private Member member;
 
     private String name; // 할 일 이름
     private Boolean isDone; // 완료 여부

--- a/src/main/java/jiwon/todo/domain/Todo.java
+++ b/src/main/java/jiwon/todo/domain/Todo.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
 
@@ -38,5 +37,10 @@ public class Todo {
         this.name = name;
         this.isDone = isDone;
         updatedAt = LocalDateTime.now();
+    }
+
+    // protected 로 제한적 접근
+    protected void setMember(Member member) {
+        this.member = member;
     }
 }

--- a/src/main/java/jiwon/todo/repository/MemberRepository.java
+++ b/src/main/java/jiwon/todo/repository/MemberRepository.java
@@ -1,4 +1,20 @@
 package jiwon.todo.repository;
 
+import jakarta.persistence.EntityManager;
+import jiwon.todo.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
 public class MemberRepository {
+    private final EntityManager em;
+
+    public void save(Member member){
+        em.persist(member);
+    }
+
+    public Member findById(Long id){
+        return em.find(Member.class, id);
+    }
 }

--- a/src/main/java/jiwon/todo/repository/MemberRepository.java
+++ b/src/main/java/jiwon/todo/repository/MemberRepository.java
@@ -17,4 +17,18 @@ public class MemberRepository {
     public Member findById(Long id){
         return em.find(Member.class, id);
     }
+
+    public boolean existsByLoginId(String loginId){
+        Long count = em.createQuery("select count(m) from Member m where m.loginId = :loginId", Long.class)
+                .setParameter("loginId", loginId)
+                .getSingleResult();
+        return count > 0;
+    }
+
+    public boolean existsByEmail(String email){
+        Long count = em.createQuery("select count(m) from Member m where m.email = :email", Long.class)
+                .setParameter("email", email)
+                .getSingleResult();
+        return count > 0;
+    }
 }

--- a/src/main/java/jiwon/todo/repository/MemberRepository.java
+++ b/src/main/java/jiwon/todo/repository/MemberRepository.java
@@ -1,0 +1,4 @@
+package jiwon.todo.repository;
+
+public class MemberRepository {
+}

--- a/src/main/java/jiwon/todo/service/MemberService.java
+++ b/src/main/java/jiwon/todo/service/MemberService.java
@@ -1,4 +1,34 @@
 package jiwon.todo.service;
 
+import jiwon.todo.domain.Member;
+import jiwon.todo.domain.Todo;
+import jiwon.todo.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class MemberService {
+
+    private MemberRepository memberRepository;
+
+    // 회원가입
+    @Transactional
+    public Long join(Member member){
+        validateDuplicateMember(member);
+        memberRepository.save(member);
+        return member.getId();
+    }
+
+    private void validateDuplicateMember(Member member) {
+        // id 중복 검사
+        // EXCEPTION
+    }
+
+    public Member findById(Long id){
+        return memberRepository.findById(id);
+    }
+
 }

--- a/src/main/java/jiwon/todo/service/MemberService.java
+++ b/src/main/java/jiwon/todo/service/MemberService.java
@@ -12,7 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MemberService {
 
-    private MemberRepository memberRepository;
+    private final MemberRepository memberRepository;
 
     // 회원가입
     @Transactional

--- a/src/main/java/jiwon/todo/service/MemberService.java
+++ b/src/main/java/jiwon/todo/service/MemberService.java
@@ -23,8 +23,13 @@ public class MemberService {
     }
 
     private void validateDuplicateMember(Member member) {
-        // id 중복 검사
-        // EXCEPTION
+        if (memberRepository.existsByLoginId(member.getLoginId())) {
+            throw new IllegalStateException("loginId is already used");
+        }
+
+        if (memberRepository.existsByEmail(member.getEmail())) {
+            throw new IllegalStateException("email is already registered.");
+        }
     }
 
     public Member findById(Long id){

--- a/src/main/java/jiwon/todo/service/MemberService.java
+++ b/src/main/java/jiwon/todo/service/MemberService.java
@@ -1,0 +1,4 @@
+package jiwon.todo.service;
+
+public class MemberService {
+}

--- a/src/test/java/jiwon/todo/service/MemberServiceTest.java
+++ b/src/test/java/jiwon/todo/service/MemberServiceTest.java
@@ -1,0 +1,32 @@
+package jiwon.todo.service;
+
+import jiwon.todo.domain.Member;
+import jiwon.todo.repository.MemberRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class MemberServiceTest {
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired MemberService memberService;
+
+    @Test
+    public void 회원가입() {
+        // given
+        Member member = new Member(100000L, "loginId", "password", "userName", "todo123@naver.com");
+
+        // when
+        Long joinedId = memberService.join(member);
+
+        // then
+        Assertions.assertEquals(member, memberRepository.findById(joinedId));
+    }
+
+}

--- a/src/test/java/jiwon/todo/service/MemberServiceTest.java
+++ b/src/test/java/jiwon/todo/service/MemberServiceTest.java
@@ -8,13 +8,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 @SpringBootTest
 @Transactional
 class MemberServiceTest {
-    @Autowired
-    MemberRepository memberRepository;
+
+    @Autowired MemberRepository memberRepository;
     @Autowired MemberService memberService;
 
     @Test

--- a/src/test/java/jiwon/todo/service/MemberServiceTest.java
+++ b/src/test/java/jiwon/todo/service/MemberServiceTest.java
@@ -18,7 +18,7 @@ class MemberServiceTest {
     @Test
     public void 회원가입() {
         // given
-        Member member = new Member(100000L, "loginId", "password", "userName", "todo123@naver.com");
+        Member member = new Member("loginId", "password", "userName", "todo123@naver.com");
 
         // when
         Long joinedId = memberService.join(member);


### PR DESCRIPTION
## 요약
회원가입 기능 및 회원가입 API 구현

## 관련 이슈
- close #3

## 📝작업 내용
- Member, Repository, Service, Controller 파일 생성
    - Member, MemberRepository, MemberService 구현
- API 구현: POST /api/members
    - MemberApiController 구현
- 입력값 유효성 검사 (이메일 형식, 중복 여부, 비밀번호 형식 등)
    - MemberForm 구현
- 회원가입 성공/실패 응답 처리
    - MemberController 구현

## 테스트 방법
1. H2 DB 실행
2. 서버 실행
3. Postman에서 회원가입 요청 테스트
    - URL: POST http://localhost:8080/api/members
    - Headers: Content-Type: application/json
    - Body (raw JSON)
4. Example Value
    - request
    ```json
    {
      "loginId": "userLoginId1",
      "password": "secretPassword0530!",
      "name": "jiwon",
      "email": "siteId1@sitename.com"
    }
    ```
    - response: 200 OK
    ``` json
    {
      "id": 1
    }
    ```

**참고사항**
이메일/아이디 중복 시 500 Internal Server Error 반환
유효성 검사 실패 시 400 Bad Request 반환

## 스크린샷
<img width="851" alt="스크린샷 2025-05-30 오전 11 38 40" src="https://github.com/user-attachments/assets/13b77c25-214c-4067-844e-f96e374542ef" />
<img width="850" alt="스크린샷 2025-05-30 오전 11 38 49" src="https://github.com/user-attachments/assets/dcf6c8b4-5ba5-4b42-8164-0f229cd00c75" />
